### PR TITLE
Update default percentiles to 90 and 99

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -34,7 +34,7 @@ kamon {
     # metric names. The implementation must have a single parameter constructor accepting a `com.typesafe.config.Config`.
     metric-key-generator = kamon.graphite.SimpleMetricKeyGenerator
 
-    percentiles = [50, 90]
+    percentiles = [90, 99]
 
     simple-metric-key-generator {
 


### PR DESCRIPTION
This PR proposes to have `90` and `99` percentile as default.

`50` is already used and corresponds to the `median` and `99` is a common metric users may be willing to have out of the box.